### PR TITLE
Workspace names for instance profile and role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -2,13 +2,13 @@
 
 # The profile of the EC2 instance
 resource "aws_iam_instance_profile" "instance_profile" {
-  name = "openvpn_instance_profile"
+  name = "openvpn_instance_profile_${terraform.workspace}"
   role = aws_iam_role.instance_role.name
 }
 
 # The role for this EC2 instance
 resource "aws_iam_role" "instance_role" {
-  name               = "instance_role"
+  name               = "openvpn_instance_role_${terraform.workspace}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy_doc.json}"
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -2,13 +2,13 @@
 
 # The profile of the EC2 instance
 resource "aws_iam_instance_profile" "instance_profile" {
-  name = "openvpn_instance_profile_${terraform.workspace}"
+  name = "openvpn_instance_profile_${var.hostname}"
   role = aws_iam_role.instance_role.name
 }
 
 # The role for this EC2 instance
 resource "aws_iam_role" "instance_role" {
-  name               = "openvpn_instance_role_${terraform.workspace}"
+  name               = "openvpn_instance_role_${var.hostname}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy_doc.json}"
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -2,13 +2,13 @@
 
 # The profile of the EC2 instance
 resource "aws_iam_instance_profile" "instance_profile" {
-  name = "openvpn_instance_profile_${var.hostname}"
+  name = "openvpn_instance_profile_${local.server_fqdn}"
   role = aws_iam_role.instance_role.name
 }
 
 # The role for this EC2 instance
 resource "aws_iam_role" "instance_role" {
-  name               = "openvpn_instance_role_${var.hostname}"
+  name               = "openvpn_instance_role_${local.server_fqdn}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy_doc.json}"
 }
 


### PR DESCRIPTION
Add workspace to name of instance profile and instance role (as is our new custom), to avoid name collisions and enable easier identification in console.