### PR TITLE
Remove unnecessary interpolation syntax

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -4,7 +4,7 @@ module "certreadrole" {
   source = "github.com/cisagov/cert-read-role-tf-module"
 
   providers = {
-    aws = "aws.cert_read_role"
+    aws = aws.cert_read_role
   }
 
   account_ids      = var.cert_read_role_accounts_allowed
@@ -18,7 +18,7 @@ module "ssmreadrole" {
   source = "github.com/cisagov/ssm-read-role-tf-module"
 
   providers = {
-    aws = "aws.ssm_read_role"
+    aws = aws.ssm_read_role
   }
 
   account_ids = var.ssm_read_role_accounts_allowed
@@ -37,14 +37,14 @@ resource "aws_iam_instance_profile" "instance_profile" {
 # The role for this EC2 instance
 resource "aws_iam_role" "instance_role" {
   name               = "openvpn_instance_role_${local.server_fqdn}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy_doc.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc.json
 }
 
 # Attach policies to the instance role
 resource "aws_iam_role_policy" "assume_delegated_role_policy" {
   name   = "assume_delegated_role_policy"
   role   = aws_iam_role.instance_role.id
-  policy = "${data.aws_iam_policy_document.assume_delegated_role_policy_doc.json}"
+  policy = data.aws_iam_policy_document.assume_delegated_role_policy_doc.json
 }
 
 ################################

--- a/route53.tf
+++ b/route53.tf
@@ -10,12 +10,12 @@ resource "aws_route53_record" "server_A" {
   name     = local.server_fqdn
   type     = "A"
   ttl      = var.ttl
-  records  = ["${aws_instance.openvpn.public_ip}"]
+  records  = [aws_instance.openvpn.public_ip]
 }
 
 resource "aws_route53_record" "server_AAAA" {
   provider = aws.dns
-  count    = "${var.create_AAAA == true ? 1 : 0}"
+  count    = var.create_AAAA == true ? 1 : 0
   zone_id  = data.aws_route53_zone.public_dns_zone.zone_id
   name     = local.server_fqdn
   type     = "AAAA"
@@ -42,7 +42,7 @@ resource "aws_route53_record" "private_PTR" {
   type = "PTR"
   ttl  = var.ttl
   records = [
-    "${local.server_fqdn}"
+    local.server_fqdn
   ]
 }
 
@@ -51,11 +51,11 @@ resource "aws_route53_record" "private_server_A" {
   name    = local.server_fqdn
   type    = "A"
   ttl     = var.ttl
-  records = ["${aws_instance.openvpn.private_ip}"]
+  records = [aws_instance.openvpn.private_ip]
 }
 
 resource "aws_route53_record" "private_server_AAAA" {
-  count   = "${var.create_AAAA == true ? 1 : 0}"
+  count   = var.create_AAAA == true ? 1 : 0
   zone_id = var.private_zone_id
   name    = local.server_fqdn
   type    = "AAAA"


### PR DESCRIPTION
## 🗣 Description

In this pull request I modify the Terraform code in several places to remove unnecessary interpolation syntax characters.  Terraform 0.12 does not require simple variable expressions to be sandwiched between `"${` and `}"`, and in fact it gives a warning if you do so.

## 💭 Motivation and Context

I have been leveraging this module for the COOL deployment, and I grow tired of seeing the annoying (but harmless) warnings.

## 🧪 Testing

I verified that all the pre-commit hooks pass, and I used the code in this pull request to successfully deploy an OpenVPN server.

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
