### PR TITLE
Add variable for the ID of the account that owns the AMI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.8'
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2-beta
         with:
           go-version: '1.13.8'
       - name: Cache pip test requirements

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module "example" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| ami_owner_account_id | The ID of the AWS account that owns the OpenVPN AMI, or "self" if the AMI is owned by the same account as the provisioner. | string | `self` | no |
 | associate\_public\_ip\_address | Whether or not to associate a public IP address with the OpenVPN server | `bool` | `true` | no |
 | aws\_instance\_type | The AWS instance type to deploy (e.g. t3.medium). | `string` | `"t3.small"` | no |
 | cert\_bucket\_name | The name of a bucket that stores certificates. (e.g. my-certs) | `string` | n/a | yes |

--- a/ami.tf
+++ b/ami.tf
@@ -1,11 +1,4 @@
 # ------------------------------------------------------------------------------
-# Deploy the AMI from cisagov/openvpn-packer in AWS.
-# ------------------------------------------------------------------------------
-
-# The AWS account ID being used
-# data "aws_caller_identity" "current" {}
-
-# ------------------------------------------------------------------------------
 # Automatically look up the latest AMI from
 # cisagov/openvpn-packer.
 #
@@ -32,6 +25,8 @@ data "aws_ami" "openvpn" {
     values = ["ebs"]
   }
 
-  owners      = ["self"]
+  owners = [
+    var.ami_owner_account_id
+  ]
   most_recent = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,11 @@ variable "trusted_cidr_blocks" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "ami_owner_account_id" {
+  description = "The ID of the AWS account that owns the OpenVPN AMI, or \"self\" if the AMI is owned by the same account as the provisioner."
+  default     = "self"
+}
+
 variable "associate_public_ip_address" {
   type        = bool
   description = "Whether or not to associate a public IP address with the OpenVPN server"


### PR DESCRIPTION
## 🗣 Description

In this pull request I add an input variable for the ID of the account that owns the AMI.  The default value for this variable is `self`, so the module behaves just as it did previously unless you specify a different value for the new value.

## 💭 Motivation and Context

Previously the owner was hardcoded to `self`, which will not work when deploying to the COOL.  We need to specify the images account ID as the owner of the AMI in that case.

## 🧪 Testing

All the pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
