### PR TITLE
Assorted bugfixes made while debugging deployment to the COOL

### DIFF
--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -19,7 +19,7 @@ data "template_cloudinit_config" "cloud_init_tasks" {
     content = templatefile(
       "${path.module}/cloudinit/install-certificates.py", {
         cert_bucket_name   = var.cert_bucket_name
-        cert_read_role_arn = module.certreadrole.arn
+        cert_read_role_arn = module.certreadrole.role.arn
         server_fqdn        = local.server_fqdn
     })
   }

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -20,7 +20,7 @@ data "template_cloudinit_config" "cloud_init_tasks" {
       "${path.module}/cloudinit/install-certificates.py", {
         cert_bucket_name   = var.cert_bucket_name
         cert_read_role_arn = module.certreadrole.role.arn
-        server_fqdn        = local.server_fqdn
+        server_fqdn        = var.hostname
     })
   }
 
@@ -40,7 +40,7 @@ data "template_cloudinit_config" "cloud_init_tasks" {
     content = templatefile(
       "${path.module}/cloudinit/freeipa-creds.tpl.yml", {
         admin_pw = var.freeipa_admin_pw
-        hostname = local.server_fqdn
+        hostname = var.hostname
         realm    = var.freeipa_realm
     })
   }

--- a/iam.tf
+++ b/iam.tf
@@ -9,7 +9,7 @@ module "certreadrole" {
 
   account_ids      = var.cert_read_role_accounts_allowed
   cert_bucket_name = var.cert_bucket_name
-  hostname         = local.server_fqdn
+  hostname         = var.hostname
 }
 
 # Create a role that allows the instance to read its params from SSM.
@@ -23,20 +23,20 @@ module "ssmreadrole" {
 
   account_ids = var.ssm_read_role_accounts_allowed
   ssm_names   = [var.ssm_tlscrypt_key, var.ssm_dh4096_pem]
-  hostname    = local.server_fqdn
+  hostname    = var.hostname
 }
 
 # Create the IAM instance profile for the EC2 server instance
 
 # The profile of the EC2 instance
 resource "aws_iam_instance_profile" "instance_profile" {
-  name = "openvpn_instance_profile_${local.server_fqdn}"
+  name = "openvpn_instance_profile_${var.hostname}"
   role = aws_iam_role.instance_role.name
 }
 
 # The role for this EC2 instance
 resource "aws_iam_role" "instance_role" {
-  name               = "openvpn_instance_role_${local.server_fqdn}"
+  name               = "openvpn_instance_role_${var.hostname}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc.json
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,7 @@ module "certreadrole" {
 # Create a role that allows the instance to read its params from SSM.
 
 module "ssmreadrole" {
-  source = "github.com/cisagov/ssm-read-role-tf-module?ref=improvement%2Fupdate-for-the-cool"
+  source = "github.com/cisagov/ssm-read-role-tf-module"
 
   providers = {
     aws = aws.ssm_read_role

--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,7 @@ module "certreadrole" {
 # Create a role that allows the instance to read its params from SSM.
 
 module "ssmreadrole" {
-  source = "github.com/cisagov/ssm-read-role-tf-module"
+  source = "github.com/cisagov/ssm-read-role-tf-module?ref=improvement%2Fupdate-for-the-cool"
 
   providers = {
     aws = aws.ssm_read_role

--- a/iam.tf
+++ b/iam.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "assume_role_policy_doc" {
 data "aws_iam_policy_document" "assume_delegated_role_policy_doc" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["${module.certreadrole.arn}", "${module.ssmreadrole.arn}"]
+    resources = ["${module.certreadrole.role.arn}", "${module.ssmreadrole.arn}"]
     effect    = "Allow"
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -13,10 +13,4 @@ locals {
     "tcp",
     "udp"
   ]
-
-  server_fqdn = "${format("%s%s.%s",
-    var.hostname,
-    var.subdomain != "" ? format(".%s", var.subdomain) : "",
-    var.domain
-  )}"
 }

--- a/route53.tf
+++ b/route53.tf
@@ -32,11 +32,8 @@ resource "aws_route53_record" "server_AAAA" {
 resource "aws_route53_record" "private_PTR" {
   zone_id = var.private_reverse_zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa",
-    element(split(".", aws_instance.openvpn.private_ip), 3),
-    element(split(".", aws_instance.openvpn.private_ip), 2),
-    element(split(".", aws_instance.openvpn.private_ip), 1),
-    element(split(".", aws_instance.openvpn.private_ip), 0),
+    "%s",
+    element(split(".", aws_instance.openvpn.private_ip), 3)
   )
 
   type = "PTR"

--- a/route53.tf
+++ b/route53.tf
@@ -7,7 +7,7 @@ data "aws_route53_zone" "public_dns_zone" {
 resource "aws_route53_record" "server_A" {
   provider = aws.dns
   zone_id  = data.aws_route53_zone.public_dns_zone.zone_id
-  name     = local.server_fqdn
+  name     = var.hostname
   type     = "A"
   ttl      = var.ttl
   records  = [aws_instance.openvpn.public_ip]
@@ -17,7 +17,7 @@ resource "aws_route53_record" "server_AAAA" {
   provider = aws.dns
   count    = var.create_AAAA == true ? 1 : 0
   zone_id  = data.aws_route53_zone.public_dns_zone.zone_id
-  name     = local.server_fqdn
+  name     = var.hostname
   type     = "AAAA"
   ttl      = var.ttl
   records  = aws_instance.openvpn.ipv6_addresses
@@ -42,13 +42,13 @@ resource "aws_route53_record" "private_PTR" {
   type = "PTR"
   ttl  = var.ttl
   records = [
-    local.server_fqdn
+    var.hostname
   ]
 }
 
 resource "aws_route53_record" "private_server_A" {
   zone_id = var.private_zone_id
-  name    = local.server_fqdn
+  name    = var.hostname
   type    = "A"
   ttl     = var.ttl
   records = [aws_instance.openvpn.private_ip]
@@ -57,7 +57,7 @@ resource "aws_route53_record" "private_server_A" {
 resource "aws_route53_record" "private_server_AAAA" {
   count   = var.create_AAAA == true ? 1 : 0
   zone_id = var.private_zone_id
-  name    = local.server_fqdn
+  name    = var.hostname
   type    = "AAAA"
   ttl     = var.ttl
   records = aws_instance.openvpn.ipv6_addresses

--- a/route53.tf
+++ b/route53.tf
@@ -32,7 +32,7 @@ resource "aws_route53_record" "server_AAAA" {
 resource "aws_route53_record" "private_PTR" {
   zone_id = var.private_reverse_zone_id
   name = format(
-    "%s.%s.%s.%s",
+    "%s.%s.%s.%s.in-addr.arpa",
     element(split(".", aws_instance.openvpn.private_ip), 3),
     element(split(".", aws_instance.openvpn.private_ip), 2),
     element(split(".", aws_instance.openvpn.private_ip), 1),

--- a/route53.tf
+++ b/route53.tf
@@ -35,9 +35,9 @@ resource "aws_route53_record" "private_PTR" {
   # append the reverse zone name if you specify just enough of the
   # record name to "fill in" the rest of the PTR record.  For example,
   # if this record were for the IP 10.11.12.13, going into the reverse
-  # zone with name "12.11.10.in-addr-arpa", then you could provide the
-  # entire record name ("13.12.11.10.in-addr.arpa.") or just the last
-  # octet ("13").  If you do the latter, then look at the
+  # zone with name "12.11.10.in-addr-arpa.", then you could provide
+  # the entire record name ("13.12.11.10.in-addr.arpa.") or just the
+  # last octet ("13").  If you do the latter, then look at the
   # corresponding Route53 record in the AWS console, you can see that
   # the ".12.11.10.in-addr.arpa." part of the name has been
   # automatically added.  With the previous code the record was coming

--- a/route53.tf
+++ b/route53.tf
@@ -31,6 +31,20 @@ resource "aws_route53_record" "server_AAAA" {
 
 resource "aws_route53_record" "private_PTR" {
   zone_id = var.private_reverse_zone_id
+  # While fixing this I realized that Terraform and/or AWS appears to
+  # append the reverse zone name if you specify just enough of the
+  # record name to "fill in" the rest of the PTR record.  For example,
+  # if this record were for the IP 10.11.12.13, going into the reverse
+  # zone with name "12.11.10.in-addr-arpa", then you could provide the
+  # entire record name ("13.12.11.10.in-addr.arpa.") or just the last
+  # octet ("13").  If you do the latter, then look at the
+  # corresponding Route53 record in the AWS console, you can see that
+  # the ".12.11.10.in-addr.arpa." part of the name has been
+  # automatically added.  With the previous code the record was coming
+  # out as "13.12.11.10.12.11.10.in-addr.arpa.", which is what clued
+  # me into what was happening.
+  #
+  # This allows us to create PTR records more succinctly.
   name = format(
     "%s",
     element(split(".", aws_instance.openvpn.private_ip), 3)

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "freeipa_realm" {
 }
 
 variable "hostname" {
-  description = "The hostname of the OpenVPN server (e.g. vpn1)"
+  description = "The hostname of the OpenVPN server (e.g. vpn.example.com)"
 }
 
 variable "private_networks" {
@@ -61,10 +61,6 @@ variable "ssm_read_role_accounts_allowed" {
   type        = list(string)
   description = "List of accounts allowed to access the role that can read SSM keys."
   default     = []
-}
-
-variable "subdomain" {
-  description = "The subdomain for the OpenVPN server.  If empty, no subdomain will be used. (e.g. cool)"
 }
 
 variable "subnet_id" {


### PR DESCRIPTION
## 🗣 Description

This PR fixes a few bugs discovered while debugging deployment of OpenVPN to the COOL:
* Make adjustments for the fact that some modules now return resources, not ARNs or IDs.
* Stop using the subdomain input variable, and instead just specify the full hostname and the domain.
* Fix a broken PTR record.

## 💭 Motivation and Context

Without these changes, this module does not deploy correctly.

## 🧪 Testing

I deployed these changes to production and verified that the OpenVPN server was able to perform all its cloud-init tasks successfully and successfully connect to the domain (FreeIPA).

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
