### PR TITLE
Use separate trusted IP lists for ssh and VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ module "example" {
   private_reverse_zone_id         = "MYREVZONEID"
   subnet_id                       = "subnet-0123456789abcdef0"
   tags                            = { "Name" : "OpenVPN Test" }
-  trusted_cidr_blocks             = ["0.0.0.0/0"]
+  trusted_cidr_blocks_ssh         = ["1.2.3.4/32"]
+  trusted_cidr_blocks_vpn         = ["0.0.0.0/0"]
 }
 ```
 
@@ -81,7 +82,8 @@ module "example" {
 | ssm_tlscrypt_key | The SSM key that contains the tls-auth key. | `string` | `/openvpn/server/tlscrypt.key` | no |
 | subnet_id | The ID of the AWS subnet to deploy into (e.g. subnet-0123456789abcdef0) | `any` | n/a | yes |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
-| trusted_cidr_blocks | A list of the CIDR blocks that are allowed to access the OpenVPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]) | `list(string)` | n/a | yes |
+| trusted_cidr_blocks_ssh | A list of the CIDR blocks that are allowed to access the ssh port on OpenVPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]) | `list(string)` | n/a | yes |
+| trusted_cidr_blocks_vpn | A list of the CIDR blocks that are allowed to access the VPN port on OpenVPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]) | `list(string)` | n/a | yes |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
 
 ## Outputs ##

--- a/locals.tf
+++ b/locals.tf
@@ -1,16 +1,11 @@
 locals {
-  # The TCP ports that the OpenVPN servers should listen on
-  openvpn_tcp_ports = [
+  # The TCP ports that the OpenVPN servers should listen on for ssh
+  ssh_tcp_ports = [
     22, # SSH
   ]
 
-  # The UDP ports that the OpenVPN servers should listen on
-  openvpn_udp_ports = [
+  # The UDP ports that the OpenVPN servers should listen on for VPN
+  vpn_udp_ports = [
     1194, # OpenVPN
-  ]
-
-  tcp_and_udp = [
-    "tcp",
-    "udp"
   ]
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -5,33 +5,34 @@ resource "aws_security_group" "openvpn_servers" {
   tags        = var.tags
 }
 
-# TCP ingress rules for OpenVPN
-resource "aws_security_group_rule" "openvpn_tcp_ingress" {
-  count = length(local.openvpn_tcp_ports)
+# TCP ingress rules for ssh
+resource "aws_security_group_rule" "ssh_tcp_ingress" {
+  count = length(local.ssh_tcp_ports)
 
   security_group_id = aws_security_group.openvpn_servers.id
   type              = "ingress"
   protocol          = "tcp"
-  cidr_blocks       = var.trusted_cidr_blocks
-  from_port         = local.openvpn_tcp_ports[count.index]
-  to_port           = local.openvpn_tcp_ports[count.index]
+  cidr_blocks       = var.trusted_cidr_blocks_ssh
+  from_port         = local.ssh_tcp_ports[count.index]
+  to_port           = local.ssh_tcp_ports[count.index]
 }
 
-# UDP ingress rules for OpenVPN
-resource "aws_security_group_rule" "openvpn_udp_ingress" {
-  count = length(local.openvpn_udp_ports)
+# UDP ingress rules for VPN
+resource "aws_security_group_rule" "vpn_udp_ingress" {
+  count = length(local.vpn_udp_ports)
 
   security_group_id = aws_security_group.openvpn_servers.id
   type              = "ingress"
   protocol          = "udp"
-  cidr_blocks       = var.trusted_cidr_blocks
-  from_port         = local.openvpn_udp_ports[count.index]
-  to_port           = local.openvpn_udp_ports[count.index]
+  cidr_blocks       = var.trusted_cidr_blocks_vpn
+  from_port         = local.vpn_udp_ports[count.index]
+  to_port           = local.vpn_udp_ports[count.index]
 }
 
 # TCP egress rules for OpenVPN
-# Egress on port 443 is needed for AWS API commands (e.g. AssumeRole, which
-# is needed in order to fetch the server certificate from S3)
+#
+# Egress on port 443 is needed for AWS API commands (e.g. AssumeRole,
+# which is needed in order to fetch the server certificate from S3).
 resource "aws_security_group_rule" "openvpn_tcp_https_egress" {
   security_group_id = aws_security_group.openvpn_servers.id
   type              = "egress"

--- a/variables.tf
+++ b/variables.tf
@@ -77,9 +77,14 @@ variable "subnet_id" {
   description = "The ID of the AWS subnet to deploy into (e.g. subnet-0123456789abcdef0)"
 }
 
-variable "trusted_cidr_blocks" {
+variable "trusted_cidr_blocks_ssh" {
   type        = list(string)
-  description = "A list of the CIDR blocks that are allowed to access the OpenVPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"
+  description = "A list of the CIDR blocks that are allowed to access the ssh port on OpenVPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"
+}
+
+variable "trusted_cidr_blocks_vpn" {
+  type        = list(string)
+  description = "A list of the CIDR blocks that are allowed to access the VPN port on OpenVPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## 🗣 Description

In this PR we change the code to use separate trusted IP lists for ssh and VPN.  See also cisagov/cool-sharedservices-openvpn#6.

This PR is linked to cisagov/cool-sharedservices-openvpn#7.

## 💭 Motivation and Context

We need VPN to be accessible from any IP (since we have folks on travel) but we want to keep ssh restricted.

## 🧪 Testing

All pre-commit tests pass.  This code has already been deployed to production and works great by all accounts.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
