### PR TITLE
Move constants out of verify-cn script to a config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ module "example" {
 | freeipa_admin_pw | The password for the Kerberos admin role | `string` | n/a | yes |
 | freeipa_realm | The realm for the IPA client (e.g. EXAMPLE.COM) | `string` | n/a | yes |
 | hostname | The hostname of the OpenVPN server (e.g. vpn.example.com) | `string` | n/a | yes |
-| ldap_uri | The URI of the LDAP server (e.g. ldaps://ipa.example.com) | `string` | n/a | yes |
 | private_networks | A list of network netmasks that exist behind the VPN server.  These will be pushed to the client.  (e.g. ["10.224.0.0 255.240.0.0", "192.168.100.0 255.255.255.0"]) | `list(string)` | n/a | yes |
 | private_reverse_zone_id | The DNS Zone ID in which to create private reverse lookup records. | `string` | n/a | yes |
 | private_zone_id | The DNS Zone ID in which to create private lookup records. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ module "example" {
 | client_dns_server | The address of the DNS server to be pushed to the VPN clients. | `string` | n/a | yes |
 | client_network | A string containing the network and netmask to assign client addresses.  The server will take the first address. (e.g. "10.240.0.0 255.255.255.0") | `string` | n/a | yes |
 | create_AAAA | Whether or not to create AAAA records for the OpenVPN server | `bool` | `false` | no |
-| domain | The domain for the OpenVPN server (e.g. cyber.dhs.gov) | `any` | n/a | yes |
-| freeipa_admin_pw | The password for the Kerberos admin role | `any` | n/a | yes |
-| freeipa_realm | The realm for the IPA client (e.g. EXAMPLE.COM) | `any` | n/a | yes |
-| hostname | The hostname of the OpenVPN server (e.g. vpn.example.com) | `any` | n/a | yes |
+| domain | The domain for the OpenVPN server (e.g. cyber.dhs.gov) | `string` | n/a | yes |
+| freeipa_admin_pw | The password for the Kerberos admin role | `string` | n/a | yes |
+| freeipa_realm | The realm for the IPA client (e.g. EXAMPLE.COM) | `string` | n/a | yes |
+| hostname | The hostname of the OpenVPN server (e.g. vpn.example.com) | `string` | n/a | yes |
+| ldap_uri | The URI of the LDAP server (e.g. ldaps://ipa.example.com) | `string` | n/a | yes |
 | private_networks | A list of network netmasks that exist behind the VPN server.  These will be pushed to the client.  (e.g. ["10.224.0.0 255.240.0.0", "192.168.100.0 255.255.255.0"]) | `list(string)` | n/a | yes |
 | private_reverse_zone_id | The DNS Zone ID in which to create private reverse lookup records. | `string` | n/a | yes |
 | private_zone_id | The DNS Zone ID in which to create private lookup records. | `string` | n/a | yes |
@@ -85,19 +86,20 @@ module "example" {
 | trusted_cidr_blocks_ssh | A list of the CIDR blocks that are allowed to access the ssh port on OpenVPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]) | `list(string)` | n/a | yes |
 | trusted_cidr_blocks_vpn | A list of the CIDR blocks that are allowed to access the VPN port on OpenVPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]) | `list(string)` | n/a | yes |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
+| vpn_group | The LDAP group that grants users the permission to connect to the VPN server. (e.g. vpnusers) | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
 | arn | The EC2 instance ARN |
-| availability\_zone | The AZ where the EC2 instance is deployed |
+| availability_zone | The AZ where the EC2 instance is deployed |
 | id | The EC2 instance ID |
-| private\_ip | The private IP of the EC2 instance |
-| public\_ip | The public IP of the OpenVPN instance |
-| security\_group\_arn | The ARN of the OpenVPN server security group |
-| security\_group\_id | The ID of the OpenVPN server security group |
-| subnet\_id | The ID of the subnet where the EC2 instance is deployed |
+| private_ip | The private IP of the EC2 instance |
+| public_ip | The public IP of the OpenVPN instance |
+| security_group_arn | The ARN of the OpenVPN server security group |
+| security_group_id | The ID of the OpenVPN server security group |
+| subnet_id | The ID of the subnet where the EC2 instance is deployed |
 
 ## Contributing ##
 

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -44,7 +44,6 @@ data "template_cloudinit_config" "cloud_init_tasks" {
     content_type = "text/cloud-config"
     content = templatefile(
       "${path.module}/cloudinit/verify-cn.tpl.yml", {
-        ldap_uri  = var.ldap_uri
         realm     = var.freeipa_realm
         vpn_group = var.vpn_group
     })

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -39,6 +39,18 @@ data "template_cloudinit_config" "cloud_init_tasks" {
     merge_type = "list(append)+dict(recurse_array)+str()"
   }
 
+  part {
+    filename     = "verify-cn.yml"
+    content_type = "text/cloud-config"
+    content = templatefile(
+      "${path.module}/cloudinit/verify-cn.tpl.yml", {
+        ldap_uri  = var.ldap_uri
+        realm     = var.freeipa_realm
+        vpn_group = var.vpn_group
+    })
+    merge_type = "list(append)+dict(recurse_array)+str()"
+  }
+
   #-------------------------------------------------------------------------------
   # Shell script parts
   #-------------------------------------------------------------------------------

--- a/cloudinit/verify-cn.tpl.yml
+++ b/cloudinit/verify-cn.tpl.yml
@@ -1,0 +1,14 @@
+# cloud-config
+# vim: syntax=yaml
+---
+
+write_files:
+  - path: /etc/openvpn/server/verify-cn.yml
+    permissions: '0400'
+    owner: root:root
+    content: |
+      ---
+      # This file was created by cloud-init at boot.
+      ldap_uri: ${ldap_uri}
+      realm: ${realm}
+      vpn_group: ${vpn_group}

--- a/cloudinit/verify-cn.tpl.yml
+++ b/cloudinit/verify-cn.tpl.yml
@@ -9,6 +9,5 @@ write_files:
     content: |
       ---
       # This file was created by cloud-init at boot.
-      ldap_uri: ${ldap_uri}
       realm: ${realm}
       vpn_group: ${vpn_group}

--- a/variables.tf
+++ b/variables.tf
@@ -50,11 +50,6 @@ variable "hostname" {
   description = "The hostname of the OpenVPN server (e.g. vpn.example.com)"
 }
 
-variable "ldap_uri" {
-  type        = string
-  description = "The URI of the LDAP server (e.g. ldaps://ipa.example.com)"
-}
-
 variable "private_networks" {
   type        = list(string)
   description = "A list of network netmasks that exist behind the VPN server.  These will be pushed to the client.  (e.g. [\"10.224.0.0 255.240.0.0\", \"192.168.100.0 255.255.255.0\"])"

--- a/variables.tf
+++ b/variables.tf
@@ -31,19 +31,28 @@ variable "client_network" {
 }
 
 variable "domain" {
+  type        = string
   description = "The domain for the OpenVPN server (e.g. cyber.dhs.gov)"
 }
 
 variable "freeipa_admin_pw" {
+  type        = string
   description = "The password for the Kerberos admin role"
 }
 
 variable "freeipa_realm" {
+  type        = string
   description = "The realm for the IPA client (e.g. EXAMPLE.COM)"
 }
 
 variable "hostname" {
+  type        = string
   description = "The hostname of the OpenVPN server (e.g. vpn.example.com)"
+}
+
+variable "ldap_uri" {
+  type        = string
+  description = "The URI of the LDAP server (e.g. ldaps://ipa.example.com)"
 }
 
 variable "private_networks" {
@@ -85,6 +94,11 @@ variable "trusted_cidr_blocks_ssh" {
 variable "trusted_cidr_blocks_vpn" {
   type        = list(string)
   description = "A list of the CIDR blocks that are allowed to access the VPN port on OpenVPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"
+}
+
+variable "vpn_group" {
+  type        = string
+  description = "The LDAP group that grants users the permission to connect to the VPN server. (e.g. vpnusers)"
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This change allows the Terraform module to properly pass configurations to the script that verifies users in LDAP.  Previously the file had hard-coded values that were COOL-specific. 

<!--- Describe your changes in detail -->

- Add new cloudinit part to create a configuration file for the `verify-cn.py` script.
- Add new inputs for required variables. (this is not backwards compatible)

## 💭 Motivation and Context

Hard-coding got it working in our specific case.  This generalizes the module's usefulness. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not much.   Didn't want to curb stomp the only VPN server.   Will test better when staging is up.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
