### PR TITLE
Pass in public hosted zone ID instead of searching for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ module "example" {
   freeipa_admin_pw                = "secure!"
   freeipa_realm                   = "shark-jump.foo.org"
   subdomain                       = "fonz"
-  domain                          = "foo.org"
   client_network                  = "10.10.2.0 255.255.255.0"
   private_networks                = ["10.10.1.0 255.255.255.0"]
   private_zone_id                 = "MYZONEID"
   private_reverse_zone_id         = "MYREVZONEID"
+  public_zone_id                  = "MYPUBLICZONEID"
   subnet_id                       = "subnet-0123456789abcdef0"
   tags                            = { "Name" : "OpenVPN Test" }
   trusted_cidr_blocks_ssh         = ["1.2.3.4/32"]
@@ -68,13 +68,13 @@ module "example" {
 | client_dns_server | The address of the DNS server to be pushed to the VPN clients. | `string` | n/a | yes |
 | client_network | A string containing the network and netmask to assign client addresses.  The server will take the first address. (e.g. "10.240.0.0 255.255.255.0") | `string` | n/a | yes |
 | create_AAAA | Whether or not to create AAAA records for the OpenVPN server | `bool` | `false` | no |
-| domain | The domain for the OpenVPN server (e.g. cyber.dhs.gov) | `string` | n/a | yes |
 | freeipa_admin_pw | The password for the Kerberos admin role | `string` | n/a | yes |
 | freeipa_realm | The realm for the IPA client (e.g. EXAMPLE.COM) | `string` | n/a | yes |
 | hostname | The hostname of the OpenVPN server (e.g. vpn.example.com) | `string` | n/a | yes |
 | private_networks | A list of network netmasks that exist behind the VPN server.  These will be pushed to the client.  (e.g. ["10.224.0.0 255.240.0.0", "192.168.100.0 255.255.255.0"]) | `list(string)` | n/a | yes |
 | private_reverse_zone_id | The DNS Zone ID in which to create private reverse lookup records. | `string` | n/a | yes |
 | private_zone_id | The DNS Zone ID in which to create private lookup records. | `string` | n/a | yes |
+| public_zone_id | The DNS Zone ID in which to create public lookup records. | `string` | n/a | yes |
 | security_groups | Additional security group ids the server will join. | `list(string)` | `[]` | no |
 | ssm_dh4096_pem | The SSM key that contains the Diffie Hellman pem. | `string` | `/openvpn/server/dh4096.pem` | no |
 | ssm_read_role_accounts_allowed | List of accounts allowed to access the role that can read SSM keys. | `list(string)` | `[]` | no |

--- a/examples/default_vpc/main.tf
+++ b/examples/default_vpc/main.tf
@@ -45,8 +45,12 @@ data "aws_subnet_ids" "default" {
   vpc_id = data.aws_vpc.default.id
 }
 
-resource "aws_route53_zone" "private_reverse_zone" {
+data "aws_route53_zone" "public_zone" {
+  provider = aws.dns
+  name     = "cyber.dhs.gov"
+}
 
+resource "aws_route53_zone" "private_reverse_zone" {
   name = "in-addr.arpa."
 
   vpc {
@@ -82,11 +86,11 @@ module "example" {
   freeipa_admin_pw                = "thepassword"
   freeipa_realm                   = "COOL.CYBER.DHS.GOV"
   subdomain                       = "cool"
-  domain                          = "cyber.dhs.gov"
   client_network                  = "10.240.0.0 255.255.255.0"
   private_networks                = ["10.224.0.0 255.240.0.0"]
   private_zone_id                 = aws_route53_zone.private_zone.zone_id
   private_reverse_zone_id         = aws_route53_zone.private_reverse_zone.zone_id
+  public_zone_id                  = data.aws_route53_zone.public_zone.zone_id
   security_groups                 = var.security_groups
   subnet_id                       = tolist(data.aws_subnet_ids.default.ids)[0]
   tags                            = { "Name" : "OpenVPN Test" }

--- a/route53.tf
+++ b/route53.tf
@@ -1,12 +1,6 @@
-# Find the DNS zone for the domain
-data "aws_route53_zone" "public_dns_zone" {
-  provider = aws.dns
-  name     = var.domain
-}
-
 resource "aws_route53_record" "server_A" {
   provider = aws.dns
-  zone_id  = data.aws_route53_zone.public_dns_zone.zone_id
+  zone_id  = var.public_zone_id
   name     = var.hostname
   type     = "A"
   ttl      = var.ttl
@@ -16,7 +10,7 @@ resource "aws_route53_record" "server_A" {
 resource "aws_route53_record" "server_AAAA" {
   provider = aws.dns
   count    = var.create_AAAA == true ? 1 : 0
-  zone_id  = data.aws_route53_zone.public_dns_zone.zone_id
+  zone_id  = var.public_zone_id
   name     = var.hostname
   type     = "AAAA"
   ttl      = var.ttl

--- a/variables.tf
+++ b/variables.tf
@@ -30,11 +30,6 @@ variable "client_network" {
   description = "A string containing the network and netmask to assign client addresses.  The server will take the first address. (e.g. \"10.240.0.0 255.255.255.0\")"
 }
 
-variable "domain" {
-  type        = string
-  description = "The domain for the OpenVPN server (e.g. cyber.dhs.gov)"
-}
-
 variable "freeipa_admin_pw" {
   type        = string
   description = "The password for the Kerberos admin role"
@@ -63,6 +58,11 @@ variable "private_zone_id" {
 variable "private_reverse_zone_id" {
   type        = string
   description = "The DNS Zone ID in which to create private reverse lookup records."
+}
+
+variable "public_zone_id" {
+  type        = string
+  description = "The DNS Zone ID in which to create public lookup records."
 }
 
 variable "security_groups" {


### PR DESCRIPTION
## 🗣 Description

This pull request modifies this module, removing the `domain` input variable and adding a `public_zone_id` input variable.  Internally, it is modified to use the public hosted zone ID directly instead of searching for it via the domain.

## 💭 Motivation and Context

In cisagov/cool-dns-cyber.dhs.gov#8, @felddy pointed out that I shouldn't need to modify that repository if I instead modify this module to pass in the public hosted zone ID instead of searching for it via the domain.  This is a cleaner solution.

## 🧪 Testing

I was able to successfully deploy cisagov/cool-sharedservices-openvpn#10 using these changes.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
