### PR TITLE
Add cloud-init script to add and persist the iptables rule for NAT

### DIFF
--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -54,8 +54,9 @@ data "template_cloudinit_config" "cloud_init_tasks" {
   # Shell script parts
   #-------------------------------------------------------------------------------
 
-  # Note: The filename parameters in each part below are used to name the mime-parts of
-  # the user-data as well as the filename in the scripts directory.
+  # Note: The filename parameters in each part below are used to name
+  # the mime-parts of the user-data as well as the filename in the
+  # scripts directory.
 
   part {
     filename     = "install-certificates.py"
@@ -80,4 +81,13 @@ data "template_cloudinit_config" "cloud_init_tasks" {
     })
   }
 
+  part {
+    filename     = "create-iptables-rule-for-nat.sh"
+    content_type = "text/x-shellscript"
+    content = templatefile(
+      "${path.module}/cloudinit/create-iptables-rule-for-nat.sh", {
+        subnet_cidr            = data.aws_subnet.the_subnet.cidr_block
+        client_network_netmask = replace(var.client_network, " ", "/")
+    })
+  }
 }

--- a/cloudinit/create-iptables-rule-for-nat.sh
+++ b/cloudinit/create-iptables-rule-for-nat.sh
@@ -22,9 +22,13 @@ interface=$(ip addr show to "${subnet_cidr}" | head -n1 | cut --delimiter=":" --
 # shellcheck disable=SC2154
 client_network_cidr=$(python -c "from ipaddress import IPv4Network; print(IPv4Network(u${client_network_netmask}))")
 
-
 # Add the iptables rule for NAT
 iptables -t nat -A POSTROUTING -s "${client_network_cidr}" -o "$interface" -j MASQUERADE
 
-# Save the iptables rules to they become persistent
+# Save the iptables rules so they become persistent
+#
+# RedHat
+# iptables-save > /etc/sysconfig/iptables
+#
+# Debian
 iptables-save > /etc/iptables/rules.v4

--- a/cloudinit/create-iptables-rule-for-nat.sh
+++ b/cloudinit/create-iptables-rule-for-nat.sh
@@ -23,7 +23,7 @@ interface=$(ip addr show to "${subnet_cidr}" | head -n1 | cut --delimiter=":" --
 client_network_cidr=$(python -c "from ipaddress import IPv4Network; print(IPv4Network(u${client_network_netmask}))")
 
 # Add the iptables rule for NAT
-iptables -t nat -A POSTROUTING -s "${client_network_cidr}" -o "$interface" -j MASQUERADE
+iptables -t nat -A POSTROUTING -s "$client_network_cidr" -o "$interface" -j MASQUERADE
 
 # Save the iptables rules so they become persistent
 #

--- a/cloudinit/create-iptables-rule-for-nat.sh
+++ b/cloudinit/create-iptables-rule-for-nat.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Input variables are:
+# subnet_cidr - the subnet in which the OpenVPN server resides, in
+# CIDR notation
+# client_network_netmask - the client network, in netmask format
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# The "${subnet_cidr}" and "${client_network_netmask}" items below
+# look like shell variables but are actually replaced by the Terraform
+# templating engine.  Hence we can ignore the "undefined variable"
+# warnings from shellcheck.
+
+# shellcheck disable=SC2154
+interface=$(ip addr show to "${subnet_cidr}" | head -n1 | cut --delimiter=":" --fields=2 | sed "s/ //g")
+
+# Convert client_network from netmask format to CIDR format
+#
+# shellcheck disable=SC2154
+client_network_cidr=$(python -c "from ipaddress import IPv4Network; print(IPv4Network(u${client_network_netmask}))")
+
+
+# Add the iptables rule for NAT
+iptables -t nat -A POSTROUTING -s "${client_network_cidr}" -o "$interface" -j MASQUERADE
+
+# Save the iptables rules to they become persistent
+iptables-save > /etc/iptables/rules.v4

--- a/cloudinit/create-iptables-rule-for-nat.sh
+++ b/cloudinit/create-iptables-rule-for-nat.sh
@@ -20,7 +20,7 @@ interface=$(ip addr show to "${subnet_cidr}" | head -n1 | cut --delimiter=":" --
 # Convert client_network from netmask format to CIDR format
 #
 # shellcheck disable=SC2154
-client_network_cidr=$(python -c "from ipaddress import IPv4Network; print(IPv4Network(u${client_network_netmask}))")
+client_network_cidr=$(python3 -c "from ipaddress import IPv4Network; print(IPv4Network('${client_network_netmask}'))")
 
 # Add the iptables rule for NAT
 iptables -t nat -A POSTROUTING -s "$client_network_cidr" -o "$interface" -j MASQUERADE


### PR DESCRIPTION
## 🗣 Description

This pull request adds a cloud-init script to add and persist the necessary `iptables` rule for NAT.  This is a companion pull request to cisagov/ansible-role-openvpn#10.

## 💭 Motivation and Context

The `iptables` rule cannot be created until we know the name of the interface thta traffic flows through to get to the network in which the OpenVPN server lives.  We cannot know that until fir st boot, so that is why this cloud-init jazz is necessary.

## 🧪 Testing

I deployed to Shared Services (Staging) and verified that NAT is now enabled on the OpenVPN instance.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
