### PR TITLE
Add the AmazonSSMManagedInstanceCore policy to the instance role for the SSM agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-generic.git

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -3,4 +3,4 @@ version: "1"
 
 lineage:
   skeleton:
-    remote-url: https://github.com/cisagov/skeleton-generic.git
+    remote-url: https://github.com/cisagov/skeleton-tf-module.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 ---
 name: build
 
-on: [
-  push,
-  pull_request
-]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [apb]
 
 env:
   PIP_CACHE_DIR: ~/.cache/pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
             | sort -u) ]]; do \
-            terraform init -input=false -backend=false "$path"; \
+            terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
-  TF_CACHE_DIR: .terraform
 
 jobs:
   lint:
@@ -61,11 +60,6 @@ jobs:
         with:
           path: ${{ steps.go-cache.outputs.dir }}
           key: "${{ runner.os }}-go"
-      - name: Cache Terraform initialization
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.TF_CACHE_DIR }}
-          key: "${{ runner.os }}-terraform-initialization"
       - name: Install Terraform
         run: |
           mkdir -p ${{ env.CURL_CACHE_DIR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
-      - name: Initialize terraform
-        run: terraform init -backend=false
+      - name: Initialize Terraform
+        run: |
+          cd examples/default_vpc
+          terraform init -backend=false
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
         run: |
           cd examples/default_vpc
           terraform init -backend=false
+          cd ../..
+          terraform init -backend=false
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
       - name: Install Terraform-docs
-        run: go get github.com/segmentio/terraform-docs
+        run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
           for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,8 @@ jobs:
           pip install --upgrade --requirement requirements-test.txt
       - name: Initialize Terraform
         run: |
-          cd examples/default_vpc
           terraform init -backend=false
-          cd ../..
+          cd examples/default_vpc
           terraform init -backend=false
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
             | sort -u) ]]; do \
+            echo "Initializing '$path'..." \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,8 @@ jobs:
           pip install --upgrade --requirement requirements-test.txt
       - name: Initialize Terraform
         run: |
-          terraform init -backend=false
-          cd examples/default_vpc
-          terraform init -backend=false
+          terraform init -backend=false -input=false
+          terraform init -backend=false -input=false examples/default_vpc/
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
             | sort -u); do \
-            echo "Initializing '$path'...\n" \
+            echo "Initializing '$path'..."; \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2
         with:
-          go-version: '1.13.8'
+          go-version: '1.14.2'
       - name: Store installed Python version
         run: |
           echo "::set-env name=PY_VERSION::"\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
+      - name: Initialize terraform
+        run: terraform init -backend=false
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ env:
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
+  TF_CACHE_DIR: .terraform
 
 jobs:
   lint:
@@ -59,6 +60,11 @@ jobs:
         with:
           path: ${{ steps.go-cache.outputs.dir }}
           key: "${{ runner.os }}-go"
+      - name: Cache Terraform initialization
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.TF_CACHE_DIR }}
+          key: "${{ runner.os }}-terraform-initialization"
       - name: Install Terraform
         run: |
           mkdir -p ${{ env.CURL_CACHE_DIR }}
@@ -72,14 +78,16 @@ jobs:
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
       - name: Install Terraform-docs
         run: go get github.com/segmentio/terraform-docs
+      - name: Find and initialize Terraform directories
+        run: |
+          for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
+            | sort -u) ]]; do \
+            terraform init -input=false -backend=false "$path"; \
+            done
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
-      - name: Initialize Terraform
-        run: |
-          terraform init -backend=false -input=false
-          terraform init -backend=false -input=false examples/default_vpc/
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,9 @@ jobs:
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
-          for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
-            | sort -u) ]]; do \
-            echo "Initializing '$path'..." \
+          for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
+            | sort -u); do \
+            echo "Initializing '$path'...\n" \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,20 +14,25 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - name: Store installed Python version
+        run: |
+          echo "::set-env name=PY_VERSION::"\
+          "$(python -c "import platform;print(platform.python_version())")"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: "${{ runner.os }}-pip-test-\
+          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
+            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
-          key: "${{ runner.os }}-pre-commit-\
+          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
-      - name: Install pre-commit hooks
+      - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,5 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
+      - name: Install pre-commit hooks
+        run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on: [
   pull_request
 ]
 
+env:
+  PIP_CACHE_DIR: ~/.cache/pip
+  PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +25,7 @@ jobs:
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pip
+          path: ${{ env.PIP_CACHE_DIR }}
           key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
@@ -31,7 +35,7 @@ jobs:
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pre-commit
+          path: ${{ env.PRE_COMMIT_CACHE_DIR }}
           key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.mypy_cache
 __pycache__
 .python-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .mypy_cache
-__pycache__
 .python-version
+__pycache__

--- a/.mdl_config.json
+++ b/.mdl_config.json
@@ -3,5 +3,8 @@
     "code_blocks": false,
     "tables": false
   },
+  "MD024": {
+    "allow_different_nesting": true
+  },
   "default": true
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -74,7 +74,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -88,3 +88,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,8 +75,8 @@ repos:
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
-  - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.27.0
+  - repo: https://github.com/mcdonnnj/pre-commit-terraform.git
+    rev: v1.27.3
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.20.0
+    rev: v1.21.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.0
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -76,19 +76,19 @@ repos:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.12.0
+    rev: v1.27.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate_no_variables
+      - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.0.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.770
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,8 +75,8 @@ repos:
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
-  - repo: https://github.com/mcdonnnj/pre-commit-terraform.git
-    rev: v1.27.3
+  - repo: https://github.com/antonbabenko/pre-commit-terraform.git
+    rev: v1.29.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
       # https://github.com/hashicorp/terraform/pull/24896
       # is a proprosed fix to deal with `terraform validate` with proxy
       # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.0a2
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,10 +64,10 @@ repos:
     rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/timothycrosley/isort
     # pick the isort version you'd like to use from
     # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.21.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.0a2
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -71,12 +71,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,19 @@ repos:
     rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,8 +65,6 @@ repos:
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
     rev: 4.3.21
     hooks:
       - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.27.0
+    rev: v1.29.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.2
+    rev: 2.0.4
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ module "example" {
 | ssm_tlscrypt_key | The SSM key that contains the tls-auth key. | `string` | `/openvpn/server/tlscrypt.key` | no |
 | subnet_id | The ID of the AWS subnet to deploy into (e.g. subnet-0123456789abcdef0) | `string` | n/a | yes |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
-| trusted_cidr_blocks_ssh | A list of the CIDR blocks that are allowed to access the ssh port on OpenVPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]) | `list(string)` | n/a | yes |
 | trusted_cidr_blocks_vpn | A list of the CIDR blocks that are allowed to access the VPN port on OpenVPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]) | `list(string)` | n/a | yes |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
 | vpn_group | The LDAP group that grants users the permission to connect to the VPN server. (e.g. vpnusers) | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ module "example" {
 ## Notes ##
 
 Running `pre-commit` requires running `terraform init` in every directory that
-contains Terraform code. In this repository these are the main directory and the
-`examples/default_vpc` directory.
+contains Terraform code. In this repository, these are the main directory and
+every directory under `examples/`.
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ module "example" {
 | private_ip | The private IP of the EC2 instance |
 | subnet_id | The ID of the subnet where the EC2 instance is deployed |
 
+## Notes ##
+
+Running `pre-commit` requires running `terraform init` in every directory that
+contains Terraform code. In this repository these are the main directory and the
+`examples/default_vpc` directory.
+
 ## Contributing ##
 
 We welcome contributions!  Please see [here](CONTRIBUTING.md) for

--- a/iam.tf
+++ b/iam.tf
@@ -55,8 +55,6 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
 
 # Attach the SSM Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment" {
-  provider = aws.provisionassessment
-
   role       = aws_iam_role.instance_role.id
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -53,6 +53,14 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
+# Attach the SSM Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 ################################
 # Define the role policies below
 ################################

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,4 @@
 locals {
-  # The TCP ports that the OpenVPN servers should listen on for ssh
-  ssh_tcp_ports = [
-    22, # SSH
-  ]
-
   # The UDP ports that the OpenVPN servers should listen on for VPN
   vpn_udp_ports = [
     1194, # OpenVPN

--- a/main.tf
+++ b/main.tf
@@ -7,11 +7,6 @@
 # The AWS account ID being used
 data "aws_caller_identity" "current" {}
 
-# Default provider information.
-provider "aws" {
-  region = "us-east-1"
-}
-
 # ------------------------------------------------------------------------------
 # AUTOMATICALLY LOOK UP THE LATEST PRE-BUILT EXAMPLE AMI FROM
 # cisagov/skeleton-packer.

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,11 @@
 # The AWS account ID being used
 data "aws_caller_identity" "current" {}
 
+# Default provider information.
+provider "aws" {
+  region = "us-east-1"
+}
+
 # ------------------------------------------------------------------------------
 # AUTOMATICALLY LOOK UP THE LATEST PRE-BUILT EXAMPLE AMI FROM
 # cisagov/skeleton-packer.

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,4 @@
+# Default provider information.
+provider "aws" {
+  region = "us-east-1"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,3 @@
 # Default provider information.
 provider "aws" {
-  region = var.aws_region
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,4 @@
 # Default provider information.
 provider "aws" {
-  region = "us-east-1"
+  region = var.aws_region
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -5,18 +5,6 @@ resource "aws_security_group" "openvpn_servers" {
   tags        = var.tags
 }
 
-# TCP ingress rules for ssh
-resource "aws_security_group_rule" "ssh_tcp_ingress" {
-  count = length(local.ssh_tcp_ports)
-
-  security_group_id = aws_security_group.openvpn_servers.id
-  type              = "ingress"
-  protocol          = "tcp"
-  cidr_blocks       = var.trusted_cidr_blocks_ssh
-  from_port         = local.ssh_tcp_ports[count.index]
-  to_port           = local.ssh_tcp_ports[count.index]
-}
-
 # UDP ingress rules for VPN
 resource "aws_security_group_rule" "vpn_udp_ingress" {
   count = length(local.vpn_udp_ports)

--- a/variables.tf
+++ b/variables.tf
@@ -82,11 +82,6 @@ variable "subnet_id" {
   description = "The ID of the AWS subnet to deploy into (e.g. subnet-0123456789abcdef0)"
 }
 
-variable "trusted_cidr_blocks_ssh" {
-  type        = list(string)
-  description = "A list of the CIDR blocks that are allowed to access the ssh port on OpenVPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"
-}
-
 variable "trusted_cidr_blocks_vpn" {
   type        = list(string)
   description = "A list of the CIDR blocks that are allowed to access the VPN port on OpenVPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"

--- a/variables.tf
+++ b/variables.tf
@@ -5,14 +5,19 @@
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region to deploy into (e.g. us-east-1)"
+  default     = "us-east-1"
 }
 
 variable "aws_availability_zone" {
+  type        = string
   description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)"
+  default     = "a"
 }
 
 variable "subnet_id" {
+  type        = string
   description = "The ID of the AWS subnet to deploy into (e.g. subnet-0123456789abcdef0)"
 }
 


### PR DESCRIPTION
## 🗣 Description

This pull request adds the AWS-provided `AmazonSSMManagedInstanceCore` policy to the OpenVPN server instance role for the SSM agent.

## 💭 Motivation and Context

With [aws/amazon-ssm-agent](https://github.com/aws/amazon-ssm-agent) we can get a shell on any instance (with or without `ssh`) via the AWS control plane.  This means we do not need to open port 22 or even provide a public IP or Internet Gateway.

## 🧪 Testing

All the pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
