### PR TITLE
Modify OpenVPN configuration to store client certificates temporarily

### DIFF
--- a/cloudinit/openvpn-config.tpl.yml
+++ b/cloudinit/openvpn-config.tpl.yml
@@ -122,6 +122,14 @@ write_files:
       # Notify the client of server restarts so it can automatically reconnect.
       explicit-exit-notify 1
 
+      # Store the client certificates to this directory. This will be
+      # done before the tls-verify script is called. The certificates
+      # will use a temporary name and will be deleted when the
+      # tls-verify script returns. The file name used for the
+      # certificate is available via the peer_cert environment
+      # variable.
+      tls-export-cert /tmp
+
       # Run command cmd to verify the X509 name of a pending TLS connection that
       # has otherwise passed all other tests of certification.  This is used
       # to verify that a user has provided an authorized PIV certificate:


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
Replicate the config change in https://github.com/cisagov/ansible-role-openvpn/pull/18 so that OpenVPN temporarily stores certificates when verifying against FreeIPA.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We were unintentionally overwriting the changes to OpenVPN's `primary.conf` from https://github.com/cisagov/ansible-role-openvpn/pull/18 when `cloud-init` re-deployed that same file in this module.  By updating the template here, we fix this issue.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All automated tests pass.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
