### PR TITLE
Change cloud init script to use ufw

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 0.12"
+  # We want to hold off on 0.13 until we have tested it.
+  required_version = "~> 0.12.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us


### PR DESCRIPTION
## 🗣 Description

This pull request modifies the `create-iptables-rule-for-nat.sh` cloud-init script to make its changes via [`ufw`](https://wiki.ubuntu.com/UncomplicatedFirewall) instead of directly through `iptables` and related tools.

## 💭 Motivation and Context

We previously set up NATing using `iptables` directly.  Now that we are required to harden the OpenVPN AMI, it ends up with `ufw` installed.  As a result, it makes more sense now to set up the NAT via `ufw`, so that all the firewall configuration is consolidated and `ufw` and the `iptables-restore` toolchain don't clobber each other.

Tangentially related to cisagov/openvpn-packer#24.

See also cisagov/ansible-role-openvpn#24.

## 🧪 Testing

These changes were used to successfully deploy a new OpenVPN AMI to our staging COOL environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
