### PR TITLE
Use an EIP for the OpenVPN server's public IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,23 @@ module "example" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12 |
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| template | ~> 2.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
-| aws.dns | n/a |
-| template | n/a |
+| aws | ~> 2.0 |
+| aws.dns | ~> 2.0 |
+| template | ~> 2.0 |
 
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ami_owner_account_id | The ID of the AWS account that owns the OpenVPN AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `self` | no |
-| associate_public_ip_address | Whether or not to associate a public IP address with the OpenVPN server | `bool` | `true` | no |
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium). | `string` | `t3.small` | no |
 | cert_bucket_name | The name of a bucket that stores certificates. (e.g. my-certs) | `string` | n/a | yes |
 | cert_read_role_accounts_allowed | List of accounts allowed to access the role that can read certificates from an S3 bucket. | `list(string)` | `[]` | no |

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,11 +1,22 @@
+# The EIP for the public IP address of the OpenVPN server
+#
+# Note that the internet gateway has already been created in
+# cool-sharedservices-networking, so the is no need for a depends_on
+# for the IGW here.
+resource "aws_eip" eips {
+  count    = var.associate_public_ip_address ? 1 : 0
+  instance = aws_instance.openvpn.id
+  tags     = var.tags
+  vpc      = true
+}
+
 # The openvpn EC2 instance
 resource "aws_instance" "openvpn" {
-  ami                         = data.aws_ami.openvpn.id
-  ebs_optimized               = true
-  instance_type               = var.aws_instance_type
-  availability_zone           = data.aws_subnet.the_subnet.availability_zone
-  subnet_id                   = var.subnet_id
-  associate_public_ip_address = var.associate_public_ip_address
+  ami               = data.aws_ami.openvpn.id
+  ebs_optimized     = true
+  instance_type     = var.aws_instance_type
+  availability_zone = data.aws_subnet.the_subnet.availability_zone
+  subnet_id         = var.subnet_id
   vpc_security_group_ids = concat([
     aws_security_group.openvpn_servers.id,
   ], var.security_groups)

--- a/ec2.tf
+++ b/ec2.tf
@@ -4,7 +4,6 @@
 # cool-sharedservices-networking, so the is no need for a depends_on
 # for the IGW here.
 resource "aws_eip" eips {
-  count    = var.associate_public_ip_address ? 1 : 0
   instance = aws_instance.openvpn.id
   tags     = var.tags
   vpc      = true

--- a/variables.tf
+++ b/variables.tf
@@ -104,12 +104,6 @@ variable "ami_owner_account_id" {
   default     = "self"
 }
 
-variable "associate_public_ip_address" {
-  type        = bool
-  description = "Whether or not to associate a public IP address with the OpenVPN server"
-  default     = true
-}
-
 variable "aws_instance_type" {
   type        = string
   description = "The AWS instance type to deploy (e.g. t3.medium)."

--- a/versions.tf
+++ b/versions.tf
@@ -7,6 +7,6 @@ terraform {
   # avoid unwelcome surprises.
   required_providers {
     aws      = "~> 2.0"
-    template = "~> 2.0"
+    template = "~> 2.1"
   }
 }


### PR DESCRIPTION
## 🗣 Description

In this pull request I change the Terraform code to use an EIP for the public IP of the OpenVPN server.

## 💭 Motivation and Context

This change allows the OpenVPN server to keep the same public IP address when the EC2 instance is stopped and started.  Previously the public IP address would change when this happened.

## 🧪 Testing

I have used these changes to deploy OpenVPN to our staging COOL environment, and I have tested that the public address indeed remains the same after stopping and starting the instance.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
