### PR TITLE
Specify associate_public_ip_address as true for the EC2 instance

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -11,11 +11,12 @@ resource "aws_eip" eips {
 
 # The openvpn EC2 instance
 resource "aws_instance" "openvpn" {
-  ami               = data.aws_ami.openvpn.id
-  ebs_optimized     = true
-  instance_type     = var.aws_instance_type
-  availability_zone = data.aws_subnet.the_subnet.availability_zone
-  subnet_id         = var.subnet_id
+  ami                         = data.aws_ami.openvpn.id
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  instance_type               = var.aws_instance_type
+  availability_zone           = data.aws_subnet.the_subnet.availability_zone
+  subnet_id                   = var.subnet_id
   vpc_security_group_ids = concat([
     aws_security_group.openvpn_servers.id,
   ], var.security_groups)


### PR DESCRIPTION
## 🗣 Description

This pull request specifies `associate_public_ip_address` as `true` for the OpenVPN EC2 instance.

## 💭 Motivation and Context

This omission was an oversight on my part when I removed the input variable `associate_public_ip_address` from this Terraform module in #42.

## 🧪 Testing

I have successfully used these changes to deploy an OpenVPN instance to our staging COOL environment.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
