### PR TITLE
Fix terraform double apply issue

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -3,7 +3,7 @@
 # Note that the internet gateway has already been created in
 # cool-sharedservices-networking, so the is no need for a depends_on
 # for the IGW here.
-resource "aws_eip" eips {
+resource "aws_eip" openvpn {
   instance = aws_instance.openvpn.id
   tags     = var.tags
   vpc      = true

--- a/route53.tf
+++ b/route53.tf
@@ -4,7 +4,7 @@ resource "aws_route53_record" "server_A" {
   name     = var.hostname
   type     = "A"
   ttl      = var.ttl
-  records  = [aws_instance.openvpn.public_ip]
+  records  = [aws_eip.openvpn.public_ip]
 }
 
 resource "aws_route53_record" "server_AAAA" {


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Renames a resource
* Uses the EIP's public IP address to populate the EC2 instance's A record

## 💭 Motivation and Context

I was previously using the EC2 instance's public IP address to populate the A record, but then I end up having to run `terraform apply` twice to get the A record to properly update.  The solution is to cut out the middleman.  I believe this bug may be related to terraform-providers/terraform-provider-aws#31.

## 🧪 Testing

I used these changes to successfully deploy a new OpenVPN server to our staging COOL environment.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
