### PR TITLE
Stop using deprecated provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ module "example" {
 |------|---------|
 | terraform | ~> 0.12.0 |
 | aws | ~> 3.0 |
-| template | ~> 2.1 |
+| cloudinit | ~> 2.0 |
 
 ## Providers ##
 
@@ -58,7 +58,7 @@ module "example" {
 |------|---------|
 | aws | ~> 3.0 |
 | aws.dns | ~> 3.0 |
-| template | ~> 2.1 |
+| cloudinit | ~> 2.0 |
 
 ## Inputs ##
 

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -1,6 +1,6 @@
 # cloud-init commands for configuring OpenVPN
 
-data "template_cloudinit_config" "cloud_init_tasks" {
+data "cloudinit_config" "cloud_init_tasks" {
   gzip          = true
   base64_encode = true
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "openvpn" {
     aws_security_group.openvpn_servers.id,
   ], var.security_groups)
 
-  user_data_base64 = data.template_cloudinit_config.cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.cloud_init_tasks.rendered
 
   tags                 = var.tags
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -8,6 +8,16 @@ followed by the `terraform apply` command.
 Note that this example may create resources which cost money. Run
 `terraform destroy` when you no longer need these resources.
 
+## Requirements ##
+
+No requirements.
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
@@ -19,6 +29,7 @@ Note that this example may create resources which cost money. Run
 | cert_read_role_arn | The ARN of the role that can create roles to have read access to the S3 bucket ('cert_bucket_name' above) where certificates are stored. | `string` | n/a | yes |
 | dns_role_arn | The ARN of the role that can modify route53 DNS. (e.g. arn:aws:iam::123456789abc:role/ModifyPublicDNS) | `string` | n/a | yes |
 | freeipa_domain | The domain for the IPA client (e.g. example.com) | `string` | n/a | yes |
+| public_dns_zone_id | The DNS zone ID in which to create public lookup records. | `string` | n/a | yes |
 | security_groups | Additional security group ids the server will join. | `list(string)` | `[]` | no |
 | ssm_read_role_accounts_allowed | List of accounts allowed to access the role that can read SSM keys. | `list(string)` | `[]` | no |
 | ssm_read_role_arn | The ARN of the role that can create roles to have read access to the SSM parameters. | `string` | n/a | yes |

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws      = "~> 3.0"
-    template = "~> 2.1"
+    aws       = "~> 3.0"
+    cloudinit = "~> 2.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request gets rid of the deprecated [template Terraform provider](https://registry.terraform.io/providers/hashicorp/template/latest/docs) in favor of the [cloudinit Terraform provider](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs).

## 💭 Motivation and Context

The deprecated template provider could disappear altogether at any time.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Halt the ever-advancing threat of obsolescence

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
