### PR TITLE
Lock down the Instance Meta-Data Service (IMDS)

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -20,9 +20,18 @@ resource "aws_instance" "openvpn" {
   vpc_security_group_ids = concat([
     aws_security_group.openvpn_servers.id,
   ], var.security_groups)
-
   user_data_base64 = data.cloudinit_config.cloud_init_tasks.rendered
-
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
   tags                 = var.tags
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Explicitly enables IMDS (which is the default behavior)
* Requires the use of IMDSv2
* Restricts the retrieval of IMDSv2 tokens to this host (also the default behavior)

## 💭 Motivation and context ##

See cisagov/cool-system#174 and cisagov/cool-system#175.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I also deployed these changes to our staging COOL environment and verified that they functioned as expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
