### PR TITLE
Allow egress on port 80 for Debian updates

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # The UDP ports that the OpenVPN servers should listen on for VPN
   vpn_udp_ports = [
-    1194, # OpenVPN
+    "1194", # OpenVPN
   ]
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -6,14 +6,14 @@ resource "aws_security_group" "openvpn_servers" {
 
 # UDP ingress rules for VPN
 resource "aws_security_group_rule" "vpn_udp_ingress" {
-  count = length(local.vpn_udp_ports)
+  for_each = toset(local.vpn_udp_ports)
 
   security_group_id = aws_security_group.openvpn_servers.id
   type              = "ingress"
   protocol          = "udp"
   cidr_blocks       = var.trusted_cidr_blocks_vpn
-  from_port         = local.vpn_udp_ports[count.index]
-  to_port           = local.vpn_udp_ports[count.index]
+  from_port         = each.value
+  to_port           = each.value
 }
 
 # TCP egress rules for OpenVPN

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -18,13 +18,17 @@ resource "aws_security_group_rule" "vpn_udp_ingress" {
 
 # TCP egress rules for OpenVPN
 #
+# Egress on port 80 is necessary for Debian updates.
+#
 # Egress on port 443 is needed for AWS API commands (e.g. AssumeRole,
 # which is needed in order to fetch the server certificate from S3).
 resource "aws_security_group_rule" "openvpn_tcp_https_egress" {
+  for_each = toset(["80", "443"])
+
   security_group_id = aws_security_group.openvpn_servers.id
   type              = "egress"
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 443
-  to_port           = 443
+  from_port         = each.value
+  to_port           = each.value
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request
- Adds egress on port 80 for OpenVPN server instances
- Changes another piece of code to use `for_each` instead of `count`

## 💭 Motivation and context ##

The failure to add port 80 was an oversight on my part when I did cisagov/openvpn-packer#50.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I also applied these changes to our COOL staging environment and verified that they function as expected.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
