### PR TITLE
Disable data renegotiation in server config

### DIFF
--- a/cloudinit/openvpn-config.tpl.yml
+++ b/cloudinit/openvpn-config.tpl.yml
@@ -159,3 +159,10 @@ write_files:
       %{ if client_motd_url != "" }
       push "setenv-safe motd ${client_motd_url}"
       %{ endif }
+
+      # Disable data renegotiation setting on the server side.  The client
+      # may set this value to whatever they wish, but we do this to avoid
+      # the connection closing if the user's PIV is not inserted when the
+      # connection renegotiation is attempted.
+      reneg-sec 0
+      

--- a/cloudinit/openvpn-config.tpl.yml
+++ b/cloudinit/openvpn-config.tpl.yml
@@ -165,4 +165,3 @@ write_files:
       # the connection closing if the user's PIV is not inserted when the
       # connection renegotiation is attempted.
       reneg-sec 0
-      


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR disables the data renegotiation setting on the server side.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The client may set this value to whatever they wish, but we do this to avoid the connection closing if the user's PIV is not inserted when the connection renegotiation is attempted.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was tested in staging in conjunction with setting the client's `reneg-sec` setting to `0`.  Testing showed that if the server setting is changed to `0`, but the client does not specify a value for this setting, the renegotiation still occurs after the default duration of `3600` seconds.

Thanks to @bra1ncramp for assistance with research and testing.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
