### PR TITLE
Add cloud-init code to set the hostname at boot

### DIFF
--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -19,6 +19,25 @@ data "cloudinit_config" "cloud_init_tasks" {
   # The filename parameters are only used to identify the mime-part headers in the
   # user-data.
 
+  # Set the local hostname.
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloudinit/set-hostname.tpl.yml", {
+        # Note that the hostname must be identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = var.hostname
+        hostname = split(".", var.hostname)[0]
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
   part {
     filename     = "openvpn-config.yml"
     content_type = "text/cloud-config"

--- a/cloudinit/set-hostname.tpl.yml
+++ b/cloudinit/set-hostname.tpl.yml
@@ -1,0 +1,8 @@
+---
+
+# Set the hostname and FQDN
+#
+# For an explanation of these variables, see here:
+# https://cloudinit.readthedocs.io/en/latest/topics/modules.html#set-hostname
+fqdn: "${fqdn}"
+hostname: "${hostname}"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds `cloud-init` code to preemptively set the hostname on all OpenVPN instances.

## 💭 Motivation and context ##

We need to go ahead and set the local hostname to the correct value that will eventually be obtained from DHCP, since we make liberal use of the `{local_hostname}` placeholder in our AWS CloudWatch Agent configuration.

## 🧪 Testing ##

I verified in our staging COOL environment that these changes cause the correct hostname to be used by the CloudWatch Agent.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.