### PR TITLE
Block VPN client-to-client communication

### DIFF
--- a/cloudinit/create-iptables-rule-for-nat.sh
+++ b/cloudinit/create-iptables-rule-for-nat.sh
@@ -45,12 +45,12 @@ COMMIT
 *nat
 :POSTROUTING ACCEPT [0:0]
 
-# Forward OpenvPN client traffic.
--A POSTROUTING -s "$client_network_cidr" -o "$interface" -j MASQUERADE
+# Forward OpenVPN client traffic
+--append POSTROUTING --source "$client_network_cidr" --out-interface "$interface" --jump MASQUERADE
 
 # Don't delete the 'COMMIT' line or these nat table rules won't be processed
 COMMIT
 EOF
 
-# Activate the new nat table rules.
+# Activate the new rules added above
 ufw disable && ufw enable

--- a/cloudinit/create-iptables-rule-for-nat.sh
+++ b/cloudinit/create-iptables-rule-for-nat.sh
@@ -22,9 +22,26 @@ interface=$(ip addr show to "${subnet_cidr}" | head -n1 | cut --delimiter=":" --
 # shellcheck disable=SC2154
 client_network_cidr=$(python3 -c "from ipaddress import IPv4Network; print(IPv4Network('${client_network_netmask}'))")
 
-# Add the NAT rule to the ufw configuration.
+# Get first address in client network
+client_network_address=$(echo "$client_network_cidr" | cut --delimiter="/" --fields=1)
+
+# Get name of VPN tunnel interface
+tunnel_interface=$(ip route get "$client_network_address" | head -n1 | sed "s/^.*dev \([^ ]*\).*$/\1/")
+
+# Add rules to the ufw configuration to:
+# - Disallow packets between VPN clients
+# - Enable NAT for VPN clients
 cat << EOF >> /etc/ufw/before.rules
-# nat Table rules
+
+# Add a filter table rule
+*filter
+# Drop packets between VPN clients; first rule in ufw-before-forward chain
+--insert ufw-before-forward 1 --in-interface "$tunnel_interface" --out-interface "$tunnel_interface" --jump DROP
+
+# don't delete the 'COMMIT' line or this filter table rule won't be processed
+COMMIT
+
+# Add nat table rules
 *nat
 :POSTROUTING ACCEPT [0:0]
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a ufw/iptables rule that drops packets sent from a VPN client to another VPN client.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We never intended to allow this behavior, but it was unintentionally enabled when we set up NAT-ing for our VPN.  This PR removes that potential attack vector.

Resolves https://github.com/cisagov/ansible-role-openvpn/issues/53.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested the updated version of `create-iptables-rule-for-nat.sh` in Staging and verified that the script runs successfully, it adds the expected firewall rule, and it blocks traffic between VPN clients (I tested with `ping`).

I also confirmed that after the rule was applied, I could still connect to a Guacamole instance in Staging and control one of the instances in that environment.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##
- [x] Verify that this change has been deployed to Staging
- [x] Deploy this change to Production