### PR TITLE
Add cloud-init foo for configuring Tenable Nessus Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ module "example" {
   hostname                                  = "vpn.fonz.shark-jump.foo.org"
   freeipa_domain                            = "shark-jump.foo.org"
   freeipa_realm                             = "SHARK-JUMP.FOO.ORG"
+  nessus_hostname_key                       = "/thulsa/doom/nessus/hostname"
+  nessus_key_key                            = "/thulsa/doom/nessus/key"
+  nessus_port_key                           = "/thulsa/doom/nessus/port"
   private_networks                          = ["10.10.1.0 255.255.255.0"]
   private_zone_id                           = "MYZONEID"
   private_reverse_zone_id                   = "MYREVZONEID"
@@ -116,6 +119,11 @@ module "example" {
 | freeipa\_domain | The domain for the IPA client (e.g. example.com). | `string` | n/a | yes |
 | freeipa\_realm | The realm for the IPA client (e.g. EXAMPLE.COM). | `string` | n/a | yes |
 | hostname | The hostname of the OpenVPN server (e.g. vpn.example.com). | `string` | n/a | yes |
+| nessus\_agent\_install\_path | The install path of Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |
+| nessus\_groups | A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. ["group1", "group2"]). | `list(string)` | ```[ "COOL_Fed_32" ]``` | no |
+| nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | n/a | yes |
+| nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | n/a | yes |
+| nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port). | `string` | n/a | yes |
 | private\_networks | A list of network netmasks that exist behind the VPN server (e.g. ["10.224.0.0 255.240.0.0", "192.168.100.0 255.255.255.0"]).  These will be pushed to the client. | `list(string)` | n/a | yes |
 | private\_reverse\_zone\_id | The DNS Zone ID in which to create private reverse lookup records. | `string` | n/a | yes |
 | private\_zone\_id | The DNS Zone ID in which to create private lookup records. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ module "example" {
 | freeipa\_domain | The domain for the IPA client (e.g. example.com). | `string` | n/a | yes |
 | freeipa\_realm | The realm for the IPA client (e.g. EXAMPLE.COM). | `string` | n/a | yes |
 | hostname | The hostname of the OpenVPN server (e.g. vpn.example.com). | `string` | n/a | yes |
-| nessus\_agent\_install\_path | The install path of Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |
+| nessus\_agent\_install\_path | The install path of the Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |
 | nessus\_groups | A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. ["group1", "group2"]). | `list(string)` | ```[ "COOL_Fed_32" ]``` | no |
 | nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | n/a | yes |
 | nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | n/a | yes |

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -121,6 +121,24 @@ data "cloudinit_config" "cloud_init_tasks" {
   }
 
   part {
+    filename = "link-nessus-agent.py"
+    # Note that text/x-python is not supported here:
+    # https://cloudinit.readthedocs.io/en/latest/explanation/format.html#mime-multi-part-archive
+    content_type = "text/x-shellscript"
+    content = templatefile(
+      "${path.module}/cloudinit/link-nessus-agent.py", {
+        nessus_agent_install_path = var.nessus_agent_install_path
+        nessus_groups             = join(",", var.nessus_groups)
+        nessus_hostname_key       = var.nessus_hostname_key
+        nessus_key_key            = var.nessus_key_key
+        nessus_port_key           = var.nessus_port_key
+        ssm_read_role_arn         = module.ssmreadrole.role.arn
+        # This is the region where the IPA instance is being created
+        ssm_region = data.aws_arn.subnet.region
+    })
+  }
+
+  part {
     filename = "configure-falcon-sensor.py"
     # Note that text/x-python is not supported here:
     # https://cloudinit.readthedocs.io/en/latest/explanation/format.html#mime-multi-part-archive

--- a/cloudinit/link-nessus-agent.py
+++ b/cloudinit/link-nessus-agent.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""Link Nessus Agent to Tenable/Nessus server.
+
+This file is a template.  It must be processed by Terraform.
+"""
+
+from __future__ import annotations
+
+# Standard Python Libraries
+# Bandit triggers B404 here, but we're only using subprocess.run() and
+# doing so safely.  For more details on B404 see here:
+# https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b404-import-subprocess
+import subprocess  # nosec
+import sys
+from typing import Any
+
+# Third-Party Libraries
+import boto3
+
+# Inputs from Terraform
+NESSUS_AGENT_INSTALL_PATH: str = "${nessus_agent_install_path}"
+NESSUS_GROUPS: str = "${nessus_groups}"
+NESSUS_HOSTNAME_KEY: str = "${nessus_hostname_key}"
+NESSUS_KEY_KEY: str = "${nessus_key_key}"
+NESSUS_PORT_KEY: str = "${nessus_port_key}"
+SSM_READ_ROLE_ARN: str = "${ssm_read_role_arn}"
+SSM_REGION: str = "${ssm_region}"
+
+
+def get_parameter(ssm_client, parameter_name: str, with_decryption: bool = True) -> str:
+    """Get the value of the specified parameter."""
+    response: dict[str, Any] = ssm_client.get_parameter(
+        Name=parameter_name,
+        WithDecryption=with_decryption,
+    )
+    return response["Parameter"]["Value"]
+
+
+def main() -> int:
+    """Retrieve necessary values from SSM Parameter Store and link the Nessus Agent."""
+    # Create STS client
+    sts_client = boto3.client("sts")
+
+    # Assume the role that can read the SSM Parameter Store parameters
+    stsresponse: dict[str, Any] = sts_client.assume_role(
+        RoleArn=SSM_READ_ROLE_ARN, RoleSessionName="nessus_agent_linking"
+    )
+    newsession_id = stsresponse["Credentials"]["AccessKeyId"]
+    newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
+    newsession_token = stsresponse["Credentials"]["SessionToken"]
+
+    # Create a new client to access SSM Parameter Store using the
+    # temporary credentials
+    ssm_client = boto3.client(
+        "ssm",
+        aws_access_key_id=newsession_id,
+        aws_secret_access_key=newsession_key,
+        aws_session_token=newsession_token,
+        region_name=SSM_REGION,
+    )
+
+    # Get the values of the SSM Parameter Store parameters
+    nessus_hostname: str = get_parameter(ssm_client, NESSUS_HOSTNAME_KEY)
+    nessus_key: str = get_parameter(ssm_client, NESSUS_KEY_KEY)
+    nessus_port: str = get_parameter(ssm_client, NESSUS_PORT_KEY)
+
+    # Link the Nessus Agent
+    link_cmd: list[str] = [
+        f"{NESSUS_AGENT_INSTALL_PATH}/sbin/nessuscli",
+        "agent",
+        "link",
+        f"--key={nessus_key}",
+        f"--host={nessus_hostname}",
+        f"--port={nessus_port}",
+        f"--groups={NESSUS_GROUPS}",
+    ]
+    # Bandit triggers B603 here, but we're using subprocess.run()
+    # safely here, since the variable content in link_cmd comes
+    # directly from SSM Parameter Store.  For more details on B603 see
+    # here:
+    # https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
+    cp: subprocess.CompletedProcess = subprocess.run(link_cmd)  # nosec
+    return cp.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cloudinit/link-nessus-agent.py
+++ b/cloudinit/link-nessus-agent.py
@@ -46,9 +46,9 @@ def main() -> int:
     stsresponse: dict[str, Any] = sts_client.assume_role(
         RoleArn=SSM_READ_ROLE_ARN, RoleSessionName="nessus_agent_linking"
     )
-    newsession_id = stsresponse["Credentials"]["AccessKeyId"]
-    newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
-    newsession_token = stsresponse["Credentials"]["SessionToken"]
+    newsession_id: str = stsresponse["Credentials"]["AccessKeyId"]
+    newsession_key: str = stsresponse["Credentials"]["SecretAccessKey"]
+    newsession_token: str = stsresponse["Credentials"]["SessionToken"]
 
     # Create a new client to access SSM Parameter Store using the
     # temporary credentials

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -94,6 +94,9 @@ module "example" {
   freeipa_domain                            = var.freeipa_domain
   freeipa_realm                             = upper(var.freeipa_domain)
   hostname                                  = "vpn.${var.freeipa_domain}"
+  nessus_hostname_key                       = "/cdm/nessus/hostname"
+  nessus_key_key                            = "/cdm/nessus/key"
+  nessus_port_key                           = "/cdm/nessus/port"
   private_networks                          = ["10.240.0.16 255.255.255.240"]
   private_reverse_zone_id                   = aws_route53_zone.private_reverse_zone.zone_id
   private_zone_id                           = aws_route53_zone.private_zone.zone_id

--- a/iam.tf
+++ b/iam.tf
@@ -24,6 +24,9 @@ module "ssmreadrole" {
   ssm_names = [
     var.crowdstrike_falcon_sensor_customer_id_key,
     var.crowdstrike_falcon_sensor_tags_key,
+    var.nessus_hostname_key,
+    var.nessus_key_key,
+    var.nessus_port_key,
     var.ssm_tlscrypt_key,
     var.ssm_dh4096_pem,
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,21 @@ variable "hostname" {
   description = "The hostname of the OpenVPN server (e.g. vpn.example.com)."
 }
 
+variable "nessus_hostname_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname)."
+}
+
+variable "nessus_key_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key)."
+}
+
+variable "nessus_port_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port)."
+}
+
 variable "private_networks" {
   type        = list(string)
   description = "A list of network netmasks that exist behind the VPN server (e.g. [\"10.224.0.0 255.240.0.0\", \"192.168.100.0 255.255.255.0\"]).  These will be pushed to the client."
@@ -130,6 +145,18 @@ variable "crowdstrike_falcon_sensor_install_path" {
   type        = string
   description = "The install path of the CrowdStrike Falcon sensor (e.g. /opt/CrowdStrike)."
   default     = "/opt/CrowdStrike"
+}
+
+variable "nessus_agent_install_path" {
+  type        = string
+  description = "The install path of Nessus Agent (e.g. /opt/nessus_agent)."
+  default     = "/opt/nessus_agent"
+}
+
+variable "nessus_groups" {
+  type        = list(string)
+  description = "A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. [\"group1\", \"group2\"])."
+  default     = ["COOL_Fed_32"]
 }
 
 variable "security_groups" {

--- a/variables.tf
+++ b/variables.tf
@@ -149,7 +149,7 @@ variable "crowdstrike_falcon_sensor_install_path" {
 
 variable "nessus_agent_install_path" {
   type        = string
-  description = "The install path of Nessus Agent (e.g. /opt/nessus_agent)."
+  description = "The install path of the Nessus Agent (e.g. /opt/nessus_agent)."
   default     = "/opt/nessus_agent"
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some cloud-init foo to properly configure the Tenable Nessus Agent.

## 💭 Motivation and context ##

The Tenable Nessus Agent will not operate as expected if it is not properly configured.

## 🧪 Testing ##

All automated tests pass.  I used these changes to deploy the OpenVPN server to our staging COOL environment and verified that the server was configured as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.