### PR TITLE
Add a variable to set the size of the OpenVPN instance's root disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ module "example" {
 | private\_reverse\_zone\_id | The DNS Zone ID in which to create private reverse lookup records. | `string` | n/a | yes |
 | private\_zone\_id | The DNS Zone ID in which to create private lookup records. | `string` | n/a | yes |
 | public\_zone\_id | The DNS Zone ID in which to create public lookup records. | `string` | n/a | yes |
+| root\_disk\_size | The size of the OpenVPN instance's root disk in GiB. | `number` | `8` | no |
 | security\_groups | Additional security group ids the server will join. | `list(string)` | `[]` | no |
 | ssm\_dh4096\_pem | The SSM key that contains the Diffie Hellman pem. | `string` | `"/openvpn/server/dh4096.pem"` | no |
 | ssm\_read\_role\_accounts\_allowed | A list of accounts allowed to access the role that can read SSM keys. | `list(string)` | `[]` | no |

--- a/ec2.tf
+++ b/ec2.tf
@@ -31,5 +31,9 @@ resource "aws_instance" "openvpn" {
     # Require IMDS tokens AKA require the use of IMDSv2
     http_tokens = "required"
   }
+  root_block_device {
+    volume_size = var.root_disk_size
+    volume_type = "gp3"
+  }
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -165,6 +165,12 @@ variable "security_groups" {
   default     = []
 }
 
+variable "root_disk_size" {
+  type        = number
+  description = "The size of the OpenVPN instance's root disk in GiB."
+  default     = 8
+}
+
 variable "ssm_dh4096_pem" {
   type        = string
   description = "The SSM key that contains the Diffie Hellman pem."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a variable to specify the size of the OpenVPN instance's root disk.

## 💭 Motivation and context ##

Resolves #98.  We need to be able to set the size to a larger value than the size of the AMI since the CDM tools can eventually consume a lot of disk space.

## 🧪 Testing ##

All automated tests pass.  I also deployed these changes to staging and verified that they functioned as expected as part of the testing for cisagov/cool-sharedservices-openvpn#71.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.