### PR TITLE
Use the ARM64 (Graviton) AMI that we are now building

### DIFF
--- a/ami.tf
+++ b/ami.tf
@@ -8,16 +8,21 @@
 
 # The AMI from cisagov/openvpn-packer
 data "aws_ami" "openvpn" {
+  most_recent = true
+  owners = [
+    var.ami_owner_account_id
+  ]
+
   filter {
-    name = "name"
-    values = [
-      "openvpn-hvm-*-x86_64-ebs",
-    ]
+    name   = "architecture"
+    values = ["arm64"]
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    name = "name"
+    values = [
+      "openvpn-hvm-*-arm64-ebs",
+    ]
   }
 
   filter {
@@ -25,8 +30,8 @@ data "aws_ami" "openvpn" {
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners = [
-    var.ami_owner_account_id
-  ]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -112,8 +112,8 @@ variable "ami_owner_account_id" {
 }
 
 variable "aws_instance_type" {
-  default     = "t3.small"
-  description = "The AWS instance type to deploy (e.g. t3.medium)."
+  default     = "t4g.small"
+  description = "The AWS instance type to deploy (e.g. t4g.medium)."
   type        = string
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Terraform module code to use the ARM64 (Graviton) AMI that we are now building.

See also:
- cisagov/openvpn-packer#113
- cisagov/cool-sharedservices-openvpn#74

## 💭 Motivation and context ##

Graviton instances are more efficient and cheaper, which is better for our pocketbook and the environment.

## 🧪 Testing ##

All automated tests pass.  I also deployed a Graviton OpenVPN instance to our staging COOL environment with these changes and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.